### PR TITLE
Fixing flare dependency.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,8 +23,14 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  flare_flutter: 1.0.2
-
+  # Use this version of flare_flutter if you are using Flutter stable channel.
+  flare_flutter: ^1.5.2
+  # Use this version if you are on Flutter dev or master channel.  
+#  flare_flutter:
+#    git: 
+#      url: git://github.com/2d-inc/Flare-Flutter.git
+#      ref: dev
+#      path: flare_flutter
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
The reason images are not showing up is because your pubspec is referencing a specific (**1.0.2** only) old version of the flare_flutter library which was built before we had added image support to Flare.

Note that you may need to tweak this depending on which flutter channel you are using as there are breaking changes between master/dev and stable. If you are on flutter stable you'll want to use the code that's currently enabled.  If you are on master or dev, you should use a reference to our dev branch as described in the commented out section.

You can find out which channel you are using by typing ```flutter channel``` into the command line.

It'll show you something like this:
```
Flutter channels:
  beta
  dev
  master
* stable
```